### PR TITLE
Latest iterations k3s with Encrypted Secrets and CRI gvisor and CNI calico additional options.

### DIFF
--- a/example/gvisor-pod-test.yml
+++ b/example/gvisor-pod-test.yml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: trusted
+  name: www-runc
+spec:
+  containers:
+  - image: nginx:1.18
+    name: www
+    ports:
+    - containerPort: 80
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: untrusted
+  name: www-gvisor
+spec:
+  runtimeClassName: gvisor
+  containers:
+  - image: nginx:1.18
+    name: www
+    ports:
+    - containerPort: 80

--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -1,5 +1,5 @@
 ---
-k3s_version: v1.25.12+k3s1
+k3s_version: v1.27.4+k3s1
 # this is the user that has ssh access to these machines
 ansible_user: ansibleuser
 systemd_dir: /etc/systemd/system
@@ -8,39 +8,60 @@ systemd_dir: /etc/systemd/system
 system_timezone: "Your/Timezone"
 
 # interface which will be used for flannel
-flannel_iface: "eth0"
+# For historical reason we keep this name for the interface even if we change our CNI to Calico.
+host_iface: "eth0"
+
+#Make sure to pick only one CNI at a time. Enable the CNI of your preference below.
+cni_calico: true
+cni_flannel: false
+
+#This parameter is only relevant if you enabled the Calico CNI above.
+cni_calico_version: "v3.26.1"
 
 # apiserver_endpoint is virtual ip-address which will be configured on each master
+# This endpoint can be set to point to HaProxy load balancer as an alternative to KubeVip. 
+# If you prefer having an external LB make sure to disable the kube_vip_configure below
+# HaProxy config not shared here. WIP
 apiserver_endpoint: "192.168.30.222"
 
 # k3s_token is required  masters can talk together securely
 # this token should be alpha numeric only
-k3s_token: "some-SUPER-DEDEUPER-secret-password"
+# This iteration made this token need absolete as it takes the token from first deployed master dynamically
+#k3s_token: "some-SUPER-DEDEUPER-secret-password"
 
 # The IP on which the node is reachable in the cluster.
 # Here, a sensible default is provided, you can still override
 # it for each of your hosts, though.
-k3s_node_ip: '{{ ansible_facts[flannel_iface]["ipv4"]["address"] }}'
+k3s_node_ip: '{{ ansible_facts[host_iface]["ipv4"]["address"] }}'  
 
 # Disable the taint manually by setting: k3s_master_taint = false
 k3s_master_taint: "{{ true if groups['node'] | default([]) | length >= 1 else false }}"
 
 # these arguments are recommended for servers as well as agents:
 extra_args: >-
-  --flannel-iface={{ flannel_iface }}
+  {{ '--flannel-iface=' + host_iface  if cni_flannel else '' }}
   --node-ip={{ k3s_node_ip }}
+
 
 # change these to your liking, the only required are: --disable servicelb, --tls-san {{ apiserver_endpoint }}
 extra_server_args: >-
   {{ extra_args }}
   {{ '--node-taint node-role.kubernetes.io/master=true:NoSchedule' if k3s_master_taint else '' }}
+  {{ '--flannel-backend=none' if cni_calico else '' }}
+  {{ '--disable-network-policy' if cni_calico else '' }}
+  {{ '--cluster-cidr=192.168.0.0/16' if cni_calico else '' }}
   --tls-san {{ apiserver_endpoint }}
   --disable servicelb
   --disable traefik
+  --kube-apiserver-arg enable-admission-plugins=NamespaceLifecycle
+  --secrets-encryption
+
 extra_agent_args: >-
   {{ extra_args }}
 
 # image tag for kube-vip
+#Install kube vip ?
+kube_vip_configure: true
 kube_vip_tag_version: "v0.5.12"
 
 # metallb type frr or native
@@ -55,8 +76,8 @@ metal_lb_mode: "layer2"
 # metal_lb_bgp_peer_address: "192.168.30.1"
 
 # image tag for metal lb
-metal_lb_speaker_tag_version: "v0.13.9"
-metal_lb_controller_tag_version: "v0.13.9"
+metal_lb_speaker_tag_version: "v0.13.10"
+metal_lb_controller_tag_version: "v0.13.10"
 
 # metallb ip range for load balancer
 metal_lb_ip_range: "192.168.30.80-192.168.30.90"
@@ -81,3 +102,10 @@ proxmox_lxc_ct_ids:
   - 202
   - 203
   - 204
+
+#Deploy gVisor CRI
+#gVisor is an application kernel, written in Go, that implements a substantial portion of the Linux system call interface.
+#It provides an additional layer of isolation between running applications and the host operating system.
+k3s_gvisor_install: true
+#gvisor param below only relevant if gvisor install is enabled above
+k3s_gvisor_version: "latest"

--- a/roles/k3s_agent/templates/k3s.service.j2
+++ b/roles/k3s_agent/templates/k3s.service.j2
@@ -7,7 +7,7 @@ After=network-online.target
 Type=notify
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/local/bin/k3s agent --server https://{{ apiserver_endpoint | ansible.utils.ipwrap }}:6443 --token {{ hostvars[groups[group_name_master | default('master')][0]]['token'] | default(k3s_token) }} {{ extra_agent_args | default("") }}
+ExecStart=/usr/local/bin/k3s agent --server https://{{ apiserver_endpoint | ansible.utils.ipwrap }}:6443 --token {{ hostvars[groups['master'][0]]['token'] }} {{ extra_agent_args | default("") }}
 KillMode=process
 Delegate=yes
 # Having non-zero Limit*s causes performance problems due to accounting overhead

--- a/roles/k3s_gvisor/tasks/gvisor.yml
+++ b/roles/k3s_gvisor/tasks/gvisor.yml
@@ -1,0 +1,45 @@
+---
+
+- name: Save original config.toml 
+  stat: path=/var/lib/rancher/k3s/agent/etc/containerd/config.toml
+  register: config_toml
+
+- name: Move config.toml to config.toml.tmpl
+  command: mv /var/lib/rancher/k3s/agent/etc/containerd/config.toml /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl
+  when: config_toml.stat.exists
+
+- name: Download gvisor runsc
+  get_url:
+    url: https://storage.googleapis.com/gvisor/releases/release/{{ k3s_gvisor_version }}/{{ ansible_facts.architecture }}/runsc
+    dest: /usr/local/bin/runsc
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Download gvisor containerd-shim
+  get_url:
+    url: https://storage.googleapis.com/gvisor/releases/release/{{ k3s_gvisor_version }}/{{ ansible_facts.architecture }}/containerd-shim-runsc-v1
+    dest: /usr/local/bin/containerd-shim-runsc-v1
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Insert/Update configuration block in /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl
+  ansible.builtin.blockinfile:
+    path: /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl
+    insertbefore: '^\[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc\]$'
+    block: |
+      disabled_plugins = ["restart"]
+      
+      [plugins."io.containerd.runtime.v1.linux"]
+        shim_debug = true
+      
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc]
+        runtime_type = "io.containerd.runsc.v1"
+
+- name: Reload and Restart K3s service
+  systemd:
+    name: k3s-node
+    daemon_reload: yes
+    state: restarted
+    enabled: yes

--- a/roles/k3s_gvisor/tasks/main.yml
+++ b/roles/k3s_gvisor/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+
+- name: Deploy gvisor ptrace Runtime CRI
+  include_tasks: gvisor.yml
+  when: vars['k3s_gvisor_install']

--- a/roles/k3s_server/defaults/main.yml
+++ b/roles/k3s_server/defaults/main.yml
@@ -1,4 +1,3 @@
----
 # If you want to explicitly define an interface that ALL control nodes
 # should use to propagate the VIP, define it here. Otherwise, kube-vip
 # will determine the right interface automatically at runtime.
@@ -6,15 +5,3 @@ kube_vip_iface: null
 
 # Name of the master group
 group_name_master: master
-
-# yamllint disable rule:line-length
-server_init_args: >-
-  {% if groups[group_name_master | default('master')] | length > 1 %}
-    {% if ansible_hostname == hostvars[groups[group_name_master | default('master')][0]]['ansible_hostname'] %}
-      --cluster-init
-    {% else %}
-      --server https://{{ hostvars[groups[group_name_master | default('master')][0]].k3s_node_ip | split(",") | first | ansible.utils.ipwrap }}:6443
-    {% endif %}
-    --token {{ k3s_token }}
-  {% endif %}
-  {{ extra_server_args | default('') }}

--- a/roles/k3s_server/tasks/calico.yml
+++ b/roles/k3s_server/tasks/calico.yml
@@ -1,0 +1,18 @@
+---
+- name: Create manifests directory on first master
+  file:
+    path: /var/lib/rancher/k3s/server/manifests
+    state: directory
+    owner: root
+    group: root
+    mode: 0644
+  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
+
+- name: "Download to first master: manifest for Calico Manifest approach"
+  ansible.builtin.get_url:
+    url: "https://raw.githubusercontent.com/projectcalico/calico/{{ cni_calico_version }}/manifests/calico.yaml"  # noqa yaml[line-length]
+    dest: "/var/lib/rancher/k3s/server/manifests/calico.yaml"
+    owner: root
+    group: root
+    mode: 0644
+  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']

--- a/roles/k3s_server/tasks/gvisor.yml
+++ b/roles/k3s_server/tasks/gvisor.yml
@@ -1,0 +1,19 @@
+---
+- name: Create manifests directory on first master
+  file:
+    path: /var/lib/rancher/k3s/server/manifests
+    state: directory
+    owner: root
+    group: root
+    mode: 0644
+  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
+
+- name: Copy gvisor runclass manifest to first master
+  template:
+    src: "runtimeclass.gvisor.j2"
+    dest: "/var/lib/rancher/k3s/server/manifests/runtimeclass-gvisor.yaml"
+    owner: root
+    group: root
+    mode: 0644
+  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
+

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -1,40 +1,98 @@
 ---
 
-- name: Stop k3s-init
+- name: Clean previous runs of k3s-init
   systemd:
     name: k3s-init
     state: stopped
   failed_when: false
 
-- name: Clean previous runs of k3s-init  # noqa command-instead-of-module
-  # The systemd module does not support "reset-failed", so we need to resort to command.
+- name: Clean previous runs of k3s-init
   command: systemctl reset-failed k3s-init
   failed_when: false
   changed_when: false
+  args:
+    warn: false  # The ansible systemd module does not support reset-failed
 
 - name: Deploy vip manifest
   include_tasks: vip.yml
+  when: vars['kube_vip_configure'] 
+
+- name: Deploy gVisor CRI runtime manifest
+  include_tasks: gvisor.yml
+  when: vars['k3s_gvisor_install'] 
+
+- name: Deploy calico CNI
+  include_tasks: calico.yml
+  when: vars['cni_calico'] 
 
 - name: Deploy metallb manifest
   include_tasks: metallb.yml
 
-- name: Init cluster inside the transient k3s-init service
+- name: Init cluster master 0 first transient k3s-init service
   command:
     cmd: "systemd-run -p RestartSec=2 \
                       -p Restart=on-failure \
                       --unit=k3s-init \
-                      k3s server {{ server_init_args }}"
+                      k3s server --cluster-init \
+                      {{ extra_server_args | default('') }}"
     creates: "{{ systemd_dir }}/k3s.service"
+  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
+
+- name: Wait for node-token
+  wait_for:
+    path: /var/lib/rancher/k3s/server/node-token
+  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
+
+- name: Register node-token file access mode
+  stat:
+    path: /var/lib/rancher/k3s/server
+  register: p
+  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
+
+- name: Change file access node-token
+  file:
+    path: /var/lib/rancher/k3s/server
+    mode: "g+rx,o+rx"
+  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
+
+- name: Read node-token from master
+  slurp:
+    src: /var/lib/rancher/k3s/server/node-token
+  register: node_token
+  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
+
+- name: Store Master node-token
+  set_fact:
+    token: "{{ node_token.content | b64decode | regex_replace('\n', '') }}"
+  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
+
+- name: Restore node-token file access
+  file:
+    path: /var/lib/rancher/k3s/server
+    mode: "{{ p.stat.mode }}"
+  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
+
+- name: Init cluster other masters other than 0 transient k3s-init service
+  command:
+    cmd: "systemd-run -p RestartSec=2 \
+                      -p Restart=on-failure \
+                      --unit=k3s-init \
+                      k3s server --server https://{{ hostvars[groups['master'][0]].k3s_node_ip | split(',') | first | ansible.utils.ipwrap }}:6443 \
+                      --token {{ hostvars[groups['master'][0]].token }} \
+                      {{ extra_server_args | default('') }}"
+    creates: "{{ systemd_dir }}/k3s.service"
+  when:
+    - ansible_hostname != hostvars[groups['master'][0]]['ansible_hostname']
+    - groups['master'] | length > 1
 
 - name: Verification
-  when: not ansible_check_mode
   block:
     - name: Verify that all nodes actually joined (check k3s-init.service if this fails)
       command:
         cmd: k3s kubectl get nodes -l "node-role.kubernetes.io/master=true" -o=jsonpath="{.items[*].metadata.name}"
       register: nodes
-      until: nodes.rc == 0 and (nodes.stdout.split() | length) == (groups[group_name_master | default('master')] | length)  # yamllint disable-line rule:line-length
-      retries: "{{ retry_count | default(20) }}"
+      until: nodes.rc == 0 and (nodes.stdout.split() | length) == (groups['master'] | length)
+      retries: "{{ retry_count | default(40) }}"
       delay: 10
       changed_when: false
   always:
@@ -49,6 +107,7 @@
         name: k3s-init
         state: stopped
       failed_when: false
+  when: not ansible_check_mode
 
 - name: Copy K3s service file
   register: k3s_service
@@ -66,33 +125,6 @@
     state: restarted
     enabled: yes
 
-- name: Wait for node-token
-  wait_for:
-    path: /var/lib/rancher/k3s/server/node-token
-
-- name: Register node-token file access mode
-  stat:
-    path: /var/lib/rancher/k3s/server
-  register: p
-
-- name: Change file access node-token
-  file:
-    path: /var/lib/rancher/k3s/server
-    mode: "g+rx,o+rx"
-
-- name: Read node-token from master
-  slurp:
-    src: /var/lib/rancher/k3s/server/node-token
-  register: node_token
-
-- name: Store Master node-token
-  set_fact:
-    token: "{{ node_token.content | b64decode | regex_replace('\n', '') }}"
-
-- name: Restore node-token file access
-  file:
-    path: /var/lib/rancher/k3s/server
-    mode: "{{ p.stat.mode }}"
 
 - name: Create directory .kube
   file:
@@ -134,25 +166,3 @@
     src: /usr/local/bin/k3s
     dest: /usr/local/bin/crictl
     state: link
-
-- name: Get contents of manifests folder
-  find:
-    paths: /var/lib/rancher/k3s/server/manifests
-    file_type: file
-  register: k3s_server_manifests
-
-- name: Get sub dirs of manifests folder
-  find:
-    paths: /var/lib/rancher/k3s/server/manifests
-    file_type: directory
-  register: k3s_server_manifests_directories
-
-- name: Remove manifests and folders that are only needed for bootstrapping cluster so k3s doesn't auto apply on start
-  file:
-    path: "{{ item.path }}"
-    state: absent
-  with_items:
-    - "{{ k3s_server_manifests.files }}"
-    - "{{ k3s_server_manifests_directories.files }}"
-  loop_control:
-    label: "{{ item.path }}"

--- a/roles/k3s_server/tasks/metallb.yml
+++ b/roles/k3s_server/tasks/metallb.yml
@@ -6,16 +6,16 @@
     owner: root
     group: root
     mode: 0644
-  when: ansible_hostname == hostvars[groups[group_name_master | default('master')][0]]['ansible_hostname']
+  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
 
 - name: "Download to first master: manifest for metallb-{{ metal_lb_type }}"
   ansible.builtin.get_url:
-    url: "https://raw.githubusercontent.com/metallb/metallb/{{ metal_lb_controller_tag_version }}/config/manifests/metallb-{{ metal_lb_type }}.yaml"  # noqa yaml[line-length]
+    url: "https://raw.githubusercontent.com/metallb/metallb/{{ metal_lb_controller_tag_version }}/config/manifests/metallb-{{metal_lb_type}}.yaml"  # noqa yaml[line-length]
     dest: "/var/lib/rancher/k3s/server/manifests/metallb-crds.yaml"
     owner: root
     group: root
     mode: 0644
-  when: ansible_hostname == hostvars[groups[group_name_master | default('master')][0]]['ansible_hostname']
+  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
 
 - name: Set image versions in manifest for metallb-{{ metal_lb_type }}
   ansible.builtin.replace:
@@ -27,4 +27,4 @@
       to: "metallb/speaker:{{ metal_lb_speaker_tag_version }}"
   loop_control:
     label: "{{ item.change }} => {{ item.to }}"
-  when: ansible_hostname == hostvars[groups[group_name_master | default('master')][0]]['ansible_hostname']
+  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']

--- a/roles/k3s_server/tasks/vip.yml
+++ b/roles/k3s_server/tasks/vip.yml
@@ -6,7 +6,7 @@
     owner: root
     group: root
     mode: 0644
-  when: ansible_hostname == hostvars[groups[group_name_master | default('master')][0]]['ansible_hostname']
+  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
 
 - name: Download vip rbac manifest to first master
   ansible.builtin.get_url:
@@ -15,7 +15,7 @@
     owner: root
     group: root
     mode: 0644
-  when: ansible_hostname == hostvars[groups[group_name_master | default('master')][0]]['ansible_hostname']
+  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
 
 - name: Copy vip manifest to first master
   template:
@@ -24,4 +24,4 @@
     owner: root
     group: root
     mode: 0644
-  when: ansible_hostname == hostvars[groups[group_name_master | default('master')][0]]['ansible_hostname']
+  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']

--- a/roles/k3s_server/templates/runtimeclass.gvisor.j2
+++ b/roles/k3s_server/templates/runtimeclass.gvisor.j2
@@ -1,0 +1,8 @@
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  # The name the RuntimeClass will be referenced by.
+  # RuntimeClass is a non-namespaced resource.
+  name: gvisor 
+# The name of the corresponding CRI configuration
+handler: runsc

--- a/roles/k3s_server_post/tasks/main.yml
+++ b/roles/k3s_server_post/tasks/main.yml
@@ -2,7 +2,27 @@
 - name: Deploy metallb pool
   include_tasks: metallb.yml
 
-- name: Remove tmp directory used for manifests
+- name: Get contents of manifests folder
+  find:
+    paths: /var/lib/rancher/k3s/server/manifests
+    file_type: file
+  register: k3s_server_manifests
+  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
+
+- name: Get sub dirs of manifests folder
+  find:
+    paths: /var/lib/rancher/k3s/server/manifests
+    file_type: directory
+  register: k3s_server_manifests_directories
+  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
+
+- name: Remove manifests and folders that are only needed for bootstrapping cluster so k3s doesn't auto apply on start
   file:
-    path: /tmp/k3s
+    path: "{{ item.path }}"
     state: absent
+  with_items:
+    - "{{ k3s_server_manifests.files }}"
+    - "{{ k3s_server_manifests_directories.files }}"
+  loop_control:
+    label: "{{ item.path }}"
+  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']

--- a/roles/k3s_server_post/tasks/metallb.yml
+++ b/roles/k3s_server_post/tasks/metallb.yml
@@ -1,30 +1,14 @@
 ---
-- name: Create manifests directory for temp configuration
-  file:
-    path: /tmp/k3s
-    state: directory
-    owner: "{{ ansible_user_id }}"
-    mode: 0755
-  with_items: "{{ groups[group_name_master | default('master')] }}"
-  run_once: true
-
-- name: Copy metallb CRs manifest to first master
-  template:
-    src: "metallb.crs.j2"
-    dest: "/tmp/k3s/metallb-crs.yaml"
-    owner: "{{ ansible_user_id }}"
-    mode: 0755
-  with_items: "{{ groups[group_name_master | default('master')] }}"
-  run_once: true
 
 - name: Test metallb-system namespace
   command: >-
     k3s kubectl -n metallb-system
   changed_when: false
-  with_items: "{{ groups[group_name_master | default('master')] }}"
+  with_items: "{{ groups['master'] }}"
   run_once: true
+  delay: 120
 
-- name: Wait for MetalLB resources
+- name: Wait for MetalLB resources. Be patient this task can take up to 30min ...
   command: >-
     k3s kubectl wait {{ item.resource }}
     --namespace='metallb-system'
@@ -32,8 +16,11 @@
     {% if item.selector | default(False) -%}--selector='{{ item.selector }}'{%- endif %}
     {% if item.condition | default(False) -%}{{ item.condition }}{%- endif %}
     --timeout='{{ metal_lb_available_timeout }}'
+  register: lsresult
+  until: "lsresult is not failed"
+  retries: "{{ retry_count | default(40) }}"    
+  delay: 45 
   changed_when: false
-  run_once: true
   with_items:
     - description: controller
       resource: deployment
@@ -66,24 +53,36 @@
   command: >-
     k3s kubectl -n metallb-system get endpoints webhook-service
   changed_when: false
-  with_items: "{{ groups[group_name_master | default('master')] }}"
+  with_items: "{{ groups['master'] }}"
   run_once: true
+  delay: 120 
 
-- name: Apply metallb CRs
-  command: >-
-    k3s kubectl apply -f /tmp/k3s/metallb-crs.yaml
-    --timeout='{{ metal_lb_available_timeout }}'
-  register: this
-  changed_when: false
-  run_once: true
-  until: this.rc == 0
-  retries: 5
+- name: Create manifests directory on first master
+  file:
+    path: /var/lib/rancher/k3s/server/manifests
+    state: directory
+    owner: root
+    group: root
+    mode: 0644
+  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
+
+- name: Copy metallb CRs manifest to first master
+  template:
+    src: "metallb.crs.j2"
+    dest: "/var/lib/rancher/k3s/server/manifests/metallb-crs.yaml"
+    owner: root
+    group: root
+    mode: 0644
+  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
 
 - name: Test metallb-system resources for Layer 2 configuration
   command: >-
     k3s kubectl -n metallb-system get {{ item }}
   changed_when: false
-  run_once: true
+  register: lsresult
+  until: lsresult.rc == 0 and (lsresult.stdout | length) > 0  
+  retries: "{{ retry_count | default(40) }}"
+  delay: 10
   when: metal_lb_mode == "layer2"
   with_items:
     - IPAddressPool
@@ -93,7 +92,10 @@
   command: >-
     k3s kubectl -n metallb-system get {{ item }}
   changed_when: false
-  run_once: true
+  register: lsresult
+  until: lsresult.rc == 0 and (lsresult.stdout | length) > 0  
+  retries: "{{ retry_count | default(40) }}"
+  delay: 10
   when: metal_lb_mode == "bgp"
   with_items:
     - IPAddressPool

--- a/site.yml
+++ b/site.yml
@@ -38,3 +38,9 @@
   roles:
     - role: k3s_server_post
       become: true
+
+- name: Install and Configure Gvisor CRI
+  hosts: node
+  roles:
+    - role: k3s_gvisor
+      become: true


### PR DESCRIPTION

# Proposed Changes
<!--- Provide a general summary of your changes -->

- Adds an option to choose between CNI's Flannel or Calico. 
- Adds an option to choose if you want to use kube_vip solution or and extrnal LB.
- Improved security. Encrypts the Secrets on the ETCD end.
-  Adds gVisor as an additional layer of isolation between running applications and the host operating system.
- Dynamic Token configuration. No need to pass a token on the inventory.

## Checklist

- [ X] Tested locally
- [ X] Ran `site.yml` playbook
- [ X] Ran `reset.yml` playbook
- [ X] Did not add any unnecessary changes
- [ X] Ran pre-commit install at least once before committing
- [ X] 🚀
